### PR TITLE
Many Association

### DIFF
--- a/lib/ork/model/associations.rb
+++ b/lib/ork/model/associations.rb
@@ -102,6 +102,39 @@ module Ork::Model
     #   class Post
     #     include Ork::Document
     #
+    #     reference :blog, :Blog
+    #   end
+    #
+    #   class Blog
+    #     include Ork::Document
+    #
+    #     many :posts, :Post
+    #   end
+    #
+    #   # is the same as
+    #
+    #   class Blog
+    #     include Ork::Document
+    #
+    #     def posts
+    #       Post.find(:blog_id => self.id)
+    #     end
+    #   end
+    #
+    def many(name, model, reference = to_reference)
+      define_method name do
+        return [] if self.id.nil?
+        model = Ork::Utils.const(self.class, model)
+        model.find(:"#{reference}_id", self.id)
+      end
+    end
+
+    # A macro for defining a method which basically does a find.
+    #
+    # Example:
+    #   class Post
+    #     include Ork::Document
+    #
     #     reference :user, :User
     #   end
     #

--- a/test/associations/many_test.rb
+++ b/test/associations/many_test.rb
@@ -1,0 +1,64 @@
+require_relative '../helper'
+
+Protest.describe 'many' do
+  class Blog
+    include Ork::Document
+    attribute :name
+
+    many :posts, :Post
+    many :weird_posts, :Post, :weird_blog
+  end
+
+  class Post
+    include Ork::Document
+    attribute :title
+
+    reference :blog, :Blog
+    reference :weird_blog, :Blog
+  end
+
+  setup do
+    randomize_bucket_name Blog
+    randomize_bucket_name Post
+  end
+
+  should 'return an empty list when there is no reference object' do
+    blog = Blog.new
+
+    assert blog.posts.empty?
+  end
+
+  test 'defines reader method but not a writer method' do
+    blog = Blog.new
+
+    assert blog.respond_to?(:posts)
+    assert !blog.respond_to?(:posts=)
+  end
+
+  should 'return the objects referenced' do
+    blog = Blog.create name: 'New'
+    post = Post.create blog: blog
+    blog.reload
+
+    assert blog.posts.include?(post)
+  end
+
+  test 'object reference with not default key' do
+    blog = Blog.create name: 'New'
+    post = Post.create weird_blog: blog
+
+    assert blog.weird_posts.include?(post)
+  end
+
+  should 'update referenced object' do
+    blog = Blog.create name: 'New'
+    post = Post.create title: 'First One'
+
+    assert blog.posts.empty?
+
+    post.blog = blog
+    post.save
+
+    assert blog.posts.include?(post)
+  end
+end


### PR DESCRIPTION
This is basically the same as `referenced` but returning the Ork::ResultSet instead of the first element.
Useful for one-to-many or many-to-many associations based on secondary indexes.
