### PR TITLE
Support quorum options

### DIFF
--- a/lib/ork/model/finders.rb
+++ b/lib/ork/model/finders.rb
@@ -11,13 +11,16 @@ module Ork::Model
     #   u == User[u.id]
     #   # => true
     #
-    def [](id)
-      load_key(id) if exist?(id)
+    def [](id, options = {})
+      load_key(id, options) if exist?(id, options)
     end
 
     # Check if the ID exists.
-    def exist?(id)
-      !id.nil? && bucket.exists?(id)
+    def exist?(id, options = {})
+      opts = {}
+      opts.merge!(r: options[:quorum].to_i) if options[:quorum]
+
+      !id.nil? && bucket.exists?(id, opts)
     end
     alias :exists? :exist?
 
@@ -69,8 +72,8 @@ module Ork::Model
 
     private
 
-    def load_key(id)
-      new.send(:load!, id)
+    def load_key(id, options)
+      new.send(:load!, id, options.merge(force: true))
     rescue Riak::FailedRequest => e
       raise e unless e.not_found?
     end

--- a/test/model/finders_test.rb
+++ b/test/model/finders_test.rb
@@ -37,6 +37,17 @@ Protest.describe 'Finders' do
     test 'return nil when the id does not belong to an object of this bucket' do
       assert_equal nil, Human['not_an_id']
     end
+
+    test 'retrieve an object with given quorum' do
+      quorum  = 1
+      robject = Human.bucket.new
+      Human.bucket.stubs(:new).returns(robject)
+      robject.expects(:reload).with(force: true, r: quorum).returns(@human1.send(:__robject))
+
+      Human[@human1.id, quorum: quorum]
+
+      Human.bucket.unstub(:new)
+    end
   end
 
   context '*exist?*' do
@@ -44,6 +55,13 @@ Protest.describe 'Finders' do
       assert !Human.exist?(nil)
       assert !Human.exist?('not_an_id')
       assert Human.exist?(@human1.id)
+    end
+
+    test 'check existence with given quorum' do
+      quorum  = 1
+      Human.bucket.expects(:exists?).once.with(@human1.id, r: quorum).returns(true)
+
+      assert Human.exist?(@human1.id, quorum: quorum)
     end
   end
 


### PR DESCRIPTION
This adds support for quorum options in `#save`, `#delete`, `#reload`,  `::[]` and `::exists?` methods.

It adds an options hash as a parameter to the methods mentioned above. The quorum should be set with the `:quorum` key.

Usage:

``` ruby
# Ork::Model#save
event.save(quorum: { w: 1, dw: 1 }) # same options than Riak::RObject#store method (:r, :w and :dw)

# Ork::Model#delete
event.delete(quorum: 2) # deletes with :rw option

# Ork::Model#reload
event.reload(quorum: 1) # reloads with :r option

# Ork::Model::[]
Event[some_id, quorum: 1] # reads with :r option

# Ork::Model::exists?
Event.exists?(some_id, quorum: 1) # reads with :r option
```
